### PR TITLE
Fix autoPopulate field name in GraphQL query

### DIFF
--- a/pages/api/viafoura/create-content.js
+++ b/pages/api/viafoura/create-content.js
@@ -21,7 +21,7 @@ const getPosts = async () => {
     headers: DATOCMS_HEADERS,
     body: JSON.stringify({
       query: `{
-        allPosts { id vfPostContainerId auto_populate slug title excerpt coverImage { url alt } }
+        allPosts { id vfPostContainerId autoPopulate slug title excerpt coverImage { url alt } }
       }`,
     }),
   });
@@ -108,7 +108,7 @@ const triggerBuildProcess = async () => {
 
 const createViafouraContent = async (allPosts, trendingArticlesCount) => {
   for (const post of allPosts) {
-    if (post.auto_populate && userComments[post.slug]) {
+    if (post.autoPopulate && userComments[post.slug]) {
       let containerUUID
       try {
         containerUUID = await getContainerUUID(post, trendingArticlesCount)


### PR DESCRIPTION
DatoCMS exposes snake_case field keys as camelCase in GraphQL. auto_populate was incorrectly renamed to snake_case in a previous commit, breaking the create-content API with an undefinedField error.