### PR TITLE
Always regenerate containers and rebuild on daily cron run

### DIFF
--- a/pages/api/viafoura/create-content.js
+++ b/pages/api/viafoura/create-content.js
@@ -50,13 +50,26 @@ const updatePostContainerId = async (postId, newVfPostContainerId) => {
 
 const getContainerUUID = async (post) => {
   const newVfPostContainerId = (post.vfPostContainerId ?? 0) + 1;
-  const response = await fetch(`${VF_LIVECOMMENTS_API}`, {
+  const createResponse = await fetch(`${VF_LIVECOMMENTS_API}`, {
     method: "POST",
     headers: VF_HEADERS,
     body: JSON.stringify({ container_id: newVfPostContainerId.toString() }),
   });
-  await handleHTTPResponseError(response);
-  const { content_container_uuid } = await response.json();
+
+  let content_container_uuid;
+  if (createResponse.status === 409) {
+    // Container already exists from a prior run where DatoCMS failed to update — look it up
+    const lookupResponse = await fetch(
+      `${VF_LIVECOMMENTS_API}/contentcontainer/id?container_id=${newVfPostContainerId}`,
+      { method: "GET", headers: VF_HEADERS },
+    );
+    await handleHTTPResponseError(lookupResponse);
+    ({ content_container_uuid } = await lookupResponse.json());
+  } else {
+    await handleHTTPResponseError(createResponse);
+    ({ content_container_uuid } = await createResponse.json());
+  }
+
   await updatePostContainerId(post.id, newVfPostContainerId);
   return content_container_uuid;
 };

--- a/pages/api/viafoura/create-content.js
+++ b/pages/api/viafoura/create-content.js
@@ -96,6 +96,7 @@ const triggerBuildProcess = async () => {
 };
 
 const createViafouraContent = async (allPosts) => {
+  let failures = 0;
   for (const post of allPosts) {
     if (post.autoPopulate && userComments[post.slug]) {
       let containerUUID;
@@ -103,6 +104,7 @@ const createViafouraContent = async (allPosts) => {
         containerUUID = await getContainerUUID(post);
       } catch (e) {
         console.error(`Failed to get container for ${post.slug}`, e);
+        failures++;
         continue;
       }
       for (const userComment of userComments[post.slug]) {
@@ -126,18 +128,24 @@ const createViafouraContent = async (allPosts) => {
           });
         } catch (e) {
           console.error(`Failed to create comment for ${post.slug}`, e);
+          failures++;
         }
       }
     }
   }
+  return failures;
 };
 
 export default async function handler(_, res) {
   try {
     const allPosts = await getPosts();
-    await createViafouraContent(allPosts);
+    const failures = await createViafouraContent(allPosts);
     await triggerBuildProcess();
-    res.status(200).json({ message: "Update Successful" });
+    if (failures > 0) {
+      res.status(207).json({ message: "Update completed with errors", failures });
+    } else {
+      res.status(200).json({ message: "Update Successful" });
+    }
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: "Internal Server Error" });

--- a/pages/api/viafoura/create-content.js
+++ b/pages/api/viafoura/create-content.js
@@ -30,8 +30,7 @@ const getPosts = async () => {
   return data.allPosts;
 };
 
-const getNewVfPostContainerId = async (postId, vfPostContainerId) => {
-  const newVfPostContainerId = vfPostContainerId + 1;
+const updatePostContainerId = async (postId, newVfPostContainerId) => {
   const response = await fetch(`${DATOCMS_API}/items/${postId}`, {
     method: "PUT",
     headers: DATOCMS_HEADERS,
@@ -47,14 +46,10 @@ const getNewVfPostContainerId = async (postId, vfPostContainerId) => {
     }),
   });
   await handleHTTPResponseError(response);
-  return newVfPostContainerId;
 };
 
 const getContainerUUID = async (post) => {
-  const newVfPostContainerId = await getNewVfPostContainerId(
-    post.id,
-    post.vfPostContainerId,
-  );
+  const newVfPostContainerId = (post.vfPostContainerId ?? 0) + 1;
   const response = await fetch(`${VF_LIVECOMMENTS_API}`, {
     method: "POST",
     headers: VF_HEADERS,
@@ -62,6 +57,7 @@ const getContainerUUID = async (post) => {
   });
   await handleHTTPResponseError(response);
   const { content_container_uuid } = await response.json();
+  await updatePostContainerId(post.id, newVfPostContainerId);
   return content_container_uuid;
 };
 
@@ -97,23 +93,27 @@ const createViafouraContent = async (allPosts) => {
         continue;
       }
       for (const userComment of userComments[post.slug]) {
-        const cookies = await getUserCookies({
-          name: userComment.name,
-          email: userComment.email,
-          password: process.env.VF_USERS_PASSWORD,
-          avatar: userComment.avatar,
-        });
-        await createComment(containerUUID, cookies, {
-          content: userComment.comment,
-          metadata: {
-            author_host_section_uuid: process.env.VF_SITE_UUID,
-            origin_summary: post.excerpt,
-            origin_title: post.title,
-            origin_url: `https://${process.env.VF_DOMAIN}/posts/${post.slug}`,
-            origin_image_url: post.coverImage.url,
-            origin_image_alt: post.coverImage.alt,
-          },
-        });
+        try {
+          const cookies = await getUserCookies({
+            name: userComment.name,
+            email: userComment.email,
+            password: process.env.VF_USERS_PASSWORD,
+            avatar: userComment.avatar,
+          });
+          await createComment(containerUUID, cookies, {
+            content: userComment.comment,
+            metadata: {
+              author_host_section_uuid: process.env.VF_SITE_UUID,
+              origin_summary: post.excerpt,
+              origin_title: post.title,
+              origin_url: `https://${process.env.VF_DOMAIN}/posts/${post.slug}`,
+              origin_image_url: post.coverImage.url,
+              origin_image_alt: post.coverImage.alt,
+            },
+          });
+        } catch (e) {
+          console.error(`Failed to create comment for ${post.slug}`, e);
+        }
       }
     }
   }

--- a/pages/api/viafoura/create-content.js
+++ b/pages/api/viafoura/create-content.js
@@ -30,16 +30,6 @@ const getPosts = async () => {
   return data.allPosts;
 };
 
-const getTrendingArticlesCount = async () => {
-  const response = await fetch(
-    `${VF_LIVECOMMENTS_API}/trending?limit=1&content_window_hours=48&sorted_by=total_visible_contents`,
-    { method: "GET", headers: VF_HEADERS },
-  );
-  await handleHTTPResponseError(response);
-  const { trending } = await response.json();
-  return trending.length;
-};
-
 const getNewVfPostContainerId = async (postId, vfPostContainerId) => {
   const newVfPostContainerId = vfPostContainerId + 1;
   const response = await fetch(`${DATOCMS_API}/items/${postId}`, {
@@ -60,29 +50,19 @@ const getNewVfPostContainerId = async (postId, vfPostContainerId) => {
   return newVfPostContainerId;
 };
 
-const getContainerUUID = async (post, trendingArticlesCount) => {
-  if (trendingArticlesCount === 0) {
-    const newVfPostContainerId = await getNewVfPostContainerId(
-      post.id,
-      post.vfPostContainerId,
-    );
-    const response = await fetch(`${VF_LIVECOMMENTS_API}`, {
-      method: "POST",
-      headers: VF_HEADERS,
-      body: JSON.stringify({ container_id: newVfPostContainerId.toString() }),
-    });
-    await handleHTTPResponseError(response);
-    const { content_container_uuid } = await response.json();
-    return content_container_uuid;
-  } else {
-    const response = await fetch(
-      `${VF_LIVECOMMENTS_API}/contentcontainer/id?container_id=${post.vfPostContainerId}`,
-      { method: "GET", headers: VF_HEADERS },
-    );
-    await handleHTTPResponseError(response);
-    const { content_container_uuid } = await response.json();
-    return content_container_uuid;
-  }
+const getContainerUUID = async (post) => {
+  const newVfPostContainerId = await getNewVfPostContainerId(
+    post.id,
+    post.vfPostContainerId,
+  );
+  const response = await fetch(`${VF_LIVECOMMENTS_API}`, {
+    method: "POST",
+    headers: VF_HEADERS,
+    body: JSON.stringify({ container_id: newVfPostContainerId.toString() }),
+  });
+  await handleHTTPResponseError(response);
+  const { content_container_uuid } = await response.json();
+  return content_container_uuid;
 };
 
 const createComment = async (containerUUID, cookies, comment) => {
@@ -106,15 +86,15 @@ const triggerBuildProcess = async () => {
   await handleHTTPResponseError(response);
 };
 
-const createViafouraContent = async (allPosts, trendingArticlesCount) => {
+const createViafouraContent = async (allPosts) => {
   for (const post of allPosts) {
     if (post.autoPopulate && userComments[post.slug]) {
-      let containerUUID
+      let containerUUID;
       try {
-        containerUUID = await getContainerUUID(post, trendingArticlesCount)
+        containerUUID = await getContainerUUID(post);
       } catch (e) {
-        console.error(`Failed to get container for ${post.slug}`, e)
-        continue
+        console.error(`Failed to get container for ${post.slug}`, e);
+        continue;
       }
       for (const userComment of userComments[post.slug]) {
         const cookies = await getUserCookies({
@@ -142,9 +122,8 @@ const createViafouraContent = async (allPosts, trendingArticlesCount) => {
 export default async function handler(_, res) {
   try {
     const allPosts = await getPosts();
-    const trendingArticlesCount = await getTrendingArticlesCount();
-    await createViafouraContent(allPosts, trendingArticlesCount);
-    if (trendingArticlesCount === 0) await triggerBuildProcess();
+    await createViafouraContent(allPosts);
+    await triggerBuildProcess();
     res.status(200).json({ message: "Update Successful" });
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
Previously the script only created new containers when trending count was zero, causing comment bloat (500+ duplicates) on existing containers. Now every run creates fresh containers, seeds clean comments, and triggers a site rebuild so articles always appear active in trending.