### PR TITLE
Add Tickaroo liveblog embed support to articles

### DIFF
--- a/components/post-body.js
+++ b/components/post-body.js
@@ -2,6 +2,9 @@ import { Image, StructuredText } from "react-datocms";
 
 import AuthorFollow from "@/components/author-follow";
 import PostTopicsFollow from "@/components/post-topics-follow";
+import TickarooEmbed, {
+  hasTickarooEmbed,
+} from "@/components/tickaroo/tickaroo-embed";
 import VfStandalonePoll from "@/components/viafoura/vf-standalone-poll";
 
 export default function PostBody({
@@ -67,6 +70,9 @@ export default function PostBody({
             );
           }
           if (record.__typename === "LiveBlogRecord") {
+            if (hasTickarooEmbed(record.liveBlog)) {
+              return <TickarooEmbed html={record.liveBlog} />;
+            }
             return (
               <div
                 className="not-prose"

--- a/components/tickaroo/tickaroo-embed.js
+++ b/components/tickaroo/tickaroo-embed.js
@@ -1,0 +1,22 @@
+import TickarooScript from "@/components/tickaroo/tickaroo-script";
+
+export function hasTickarooEmbed(html) {
+  return typeof html === "string" && /<tickaroo-/i.test(html);
+}
+
+function stripScriptTags(html) {
+  return html.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
+}
+
+export default function TickarooEmbed({ html }) {
+  if (!hasTickarooEmbed(html)) {
+    return null;
+  }
+
+  return (
+    <div className="not-prose">
+      <TickarooScript />
+      <div dangerouslySetInnerHTML={{ __html: stripScriptTags(html) }} />
+    </div>
+  );
+}

--- a/components/tickaroo/tickaroo-liveblog.js
+++ b/components/tickaroo/tickaroo-liveblog.js
@@ -1,0 +1,18 @@
+import TickarooScript from "@/components/tickaroo/tickaroo-script";
+
+export default function TickarooLiveblog({ liveblogId, themeId, clientId }) {
+  if (!liveblogId) {
+    return null;
+  }
+
+  return (
+    <div className="not-prose">
+      <TickarooScript />
+      <tickaroo-liveblog
+        liveblogid={liveblogId}
+        themeid={themeId}
+        clientid={clientId}
+      />
+    </div>
+  );
+}

--- a/components/tickaroo/tickaroo-script.js
+++ b/components/tickaroo/tickaroo-script.js
@@ -1,0 +1,14 @@
+import Script from "next/script";
+
+export const TICKAROO_EMBED_SRC =
+  "https://cdn.tickaroo.com/webng/embedjs/tik4.js";
+
+export default function TickarooScript() {
+  return (
+    <Script
+      id="tickaroo-tik4"
+      src={TICKAROO_EMBED_SRC}
+      strategy="afterInteractive"
+    />
+  );
+}


### PR DESCRIPTION
Inject tik4.js via next/script so Tickaroo custom elements upgrade, since dangerouslySetInnerHTML does not execute script tags. The existing Live Blog block now routes Tickaroo markup through TickarooEmbed.