### PR TITLE
Stop Tailwind base styles from overriding Viafoura components

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,23 +9,23 @@
   body {
     @apply font-sans;
   }
-  h1 {
+  h1:not(.viafoura *) {
     @apply text-4xl font-bold text-gray-800 antialiased;
   }
-  h2 {
+  h2:not(.viafoura *) {
     @apply text-3xl font-bold text-gray-800;
   }
-  h3 {
+  h3:not(.viafoura *) {
     @apply text-2xl font-semibold text-gray-800;
   }
-  h1,
-  h2,
-  h3,
-  p,
-  div {
+  h1:not(.viafoura *),
+  h2:not(.viafoura *),
+  h3:not(.viafoura *),
+  p:not(.viafoura *),
+  div:not(.viafoura):not(.viafoura *) {
     @apply dark:text-white;
   }
-  svg {
+  svg:not(.viafoura *) {
     @apply inline align-baseline;
   }
 }
@@ -57,10 +57,14 @@ nav .viafoura .vf-tray-trigger:focus {
 #vf-broadcast-notification label {
   @apply text-sm font-semibold text-stone-600;
 }
-#vf-broadcast-notification input,
-#vf-broadcast-notification select,
+#vf-broadcast-notification input {
+  @apply form-input mb-4 mt-1 w-full rounded border-stone-300 text-sm text-stone-600 focus:ring-stone-400;
+}
+#vf-broadcast-notification select {
+  @apply form-select mb-4 mt-1 w-full rounded border-stone-300 text-sm text-stone-600 focus:ring-stone-400;
+}
 #vf-broadcast-notification textarea {
-  @apply mb-4 mt-1 w-full rounded border-stone-300 text-sm text-stone-600 focus:ring-stone-400;
+  @apply form-textarea mb-4 mt-1 w-full rounded border-stone-300 text-sm text-stone-600 focus:ring-stone-400;
 }
 #vf-broadcast-notification button {
   @apply m-auto mb-2 mt-4 flex rounded bg-indigo-500 px-6 py-4 text-base text-white hover:bg-indigo-600 disabled:bg-indigo-300;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,5 +16,8 @@ module.exports = {
       xl: "1280px",
     },
   },
-  plugins: [require("@tailwindcss/typography"), require("@tailwindcss/forms")],
+  plugins: [
+    require("@tailwindcss/typography"),
+    require("@tailwindcss/forms")({ strategy: "class" }),
+  ],
 };


### PR DESCRIPTION
The @tailwindcss/forms plugin defaulted to its ['base', 'class'] strategy, emitting unscoped [type='radio'] and [type='checkbox'] selectors. These overrode Viafoura's scoped reset and painted a currentColor fill plus a second SVG indicator over Viafoura's own radio mark, breaking checked radios in the report dialog.

Switch the plugin to the 'class' strategy and opt the broadcast form in explicitly, since it holds the only native form controls on the site.

Also scope the base-layer heading, paragraph, div and svg rules so they no longer apply inside .viafoura widget roots.