### PR TITLE
Keep poll radio outline visible on focus

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -82,7 +82,7 @@ nav .viafoura .vf-tray-trigger:focus {
 .viafoura {
   --reserved-space-top: 62px !important;
 }
-.viafoura input:focus,
+.viafoura input:focus:not([type="radio"]):not([type="checkbox"]),
 .viafoura textarea:focus {
   border: none !important;
   box-shadow: none !important;


### PR DESCRIPTION
The .viafoura input:focus rule was written for the comment and login text fields, but it matched every input inside a Viafoura widget. Poll radios use appearance: none with a transparent background, so their 2px border is the only thing painting the circle — focusing one wiped it and the option looked empty even though the vote registered.

Exclude radio and checkbox inputs from the reset.